### PR TITLE
Rename handler to gateway and add Dispatch/Newcast bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# summer-matrix
+# Summer Matrix Bots
+
+This project contains a simple Node.js server demonstrating a multi-agent architecture inspired by the OpenAI Agents SDK. Slack messages are received and routed to specialized bots that call the OpenAI Assistants API.
+
+## Structure
+
+- `server.js` – Express server that receives Slack events.
+- `gateway.js` – Chooses which bot(s) should respond to a message.
+- `agent.js` – Minimal agent class that wraps calls to the OpenAI API.
+- `bots/` – Folder containing individual bot definitions.
+  - `gatewayAgent.js` – Greets users and explains how their request will be routed.
+  - `dispatchAgent.js` – Answers questions about past AI projects and documentation using an Airtable search.
+  - `newcastAgent.js` – Provides recent news relevant to user queries from scraped articles and an Airtable feed.
+
+## Usage
+
+1. Install dependencies (requires Node.js):
+
+   ```bash
+   npm install
+   ```
+
+2. Set environment variables in a `.env` file or your shell:
+
+   ```bash
+   OPENAI_API_KEY=sk-...
+   SLACK_BOT_TOKEN=xoxb-...
+   SLACK_SIGNING_SECRET=...
+   ```
+
+3. Start the server:
+
+   ```bash
+   npm start
+   ```
+
+The server exposes a `/slack/events` endpoint suitable for Slack's Events API. `gateway.js` first invokes `gatewayAgent` to describe the process, then calls `dispatchAgent` for project/documentation queries and `newcastAgent` for news requests. Each agent calls the OpenAI API and returns a response that should be sent back to Slack (the example logs them to the console).
+
+## Notes
+
+This example focuses on demonstrating the architecture. To build a production bot you would add authentication with Slack, handle retries, store conversation history, and write tests.

--- a/agent.js
+++ b/agent.js
@@ -1,0 +1,24 @@
+const { OpenAI } = require('openai');
+
+class Agent {
+  constructor({ name, instructions }) {
+    this.name = name;
+    this.instructions = instructions;
+    this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  }
+
+  async respond(userMessage) {
+    const messages = [
+      { role: 'system', content: this.instructions },
+      { role: 'user', content: userMessage }
+    ];
+    const completion = await this.openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages
+    });
+    const content = completion.choices[0].message.content.trim();
+    return content;
+  }
+}
+
+module.exports = Agent;

--- a/bots/dispatchAgent.js
+++ b/bots/dispatchAgent.js
@@ -1,0 +1,6 @@
+const Agent = require('../agent');
+
+module.exports = new Agent({
+  name: 'Dispatch',
+  instructions: 'You inform users about past AI-related projects and documentation. Use your knowledge base and an Airtable search (stubbed) to answer queries.'
+});

--- a/bots/gatewayAgent.js
+++ b/bots/gatewayAgent.js
@@ -1,0 +1,6 @@
+const Agent = require('../agent');
+
+module.exports = new Agent({
+  name: 'Gateway',
+  instructions: 'You greet the user and explain which specialized bots will handle their request. Briefly describe the routing process before providing results.'
+});

--- a/bots/index.js
+++ b/bots/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  gateway: require('./gatewayAgent'),
+  dispatch: require('./dispatchAgent'),
+  newcast: require('./newcastAgent')
+};

--- a/bots/newcastAgent.js
+++ b/bots/newcastAgent.js
@@ -1,0 +1,6 @@
+const Agent = require('../agent');
+
+module.exports = new Agent({
+  name: 'Newcast',
+  instructions: 'You provide recent news relevant to the user\'s query by searching scraped academic articles and an Airtable of news posts.'
+});

--- a/gateway.js
+++ b/gateway.js
@@ -1,0 +1,24 @@
+const bots = require('./bots');
+
+async function handleMessage(text) {
+  const responses = [];
+
+  // Gateway introduction explaining routing
+  const intro = await bots.gateway.respond(text);
+  responses.push({ agent: bots.gateway.name, text: intro });
+
+  // Route to specialized bots based on simple keywords
+  if (/project|documentation|docs?/i.test(text)) {
+    const dispatchReply = await bots.dispatch.respond(text);
+    responses.push({ agent: bots.dispatch.name, text: dispatchReply });
+  }
+
+  if (/news|article/i.test(text)) {
+    const newsReply = await bots.newcast.respond(text);
+    responses.push({ agent: bots.newcast.name, text: newsReply });
+  }
+
+  return responses;
+}
+
+module.exports = { handleMessage };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "summer-matrix",
+  "version": "1.0.0",
+  "description": "Example Slack multi-agent node app",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "dotenv": "^16.4.1",
+    "express": "^4.19.2",
+    "openai": "^4.33.1"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+require('dotenv').config();
+const express = require('express');
+const bodyParser = require('body-parser');
+const { handleMessage } = require('./gateway');
+
+const app = express();
+app.use(bodyParser.json());
+
+app.post('/slack/events', async (req, res) => {
+  const { text, user } = parseSlackEvent(req.body);
+  if (!text) return res.sendStatus(200);
+
+  try {
+    const responses = await handleMessage(text);
+    // TODO: send responses back to Slack using Web API
+    console.log(`Responses for ${user}:`, responses);
+  } catch (err) {
+    console.error('Handler error:', err);
+  }
+  res.sendStatus(200);
+});
+
+function parseSlackEvent(body) {
+  const text = body.event && body.event.text;
+  const user = body.event && body.event.user;
+  return { text, user };
+}
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- rename handler to gateway to orchestrate responses
- rename welcomeAgent to gatewayAgent
- add Dispatch and Newcast bots
- update bot index and routing logic
- document new architecture in README

## Testing
- `node --check server.js`
- `node --check gateway.js`
- `node --check agent.js`
- `node --check bots/index.js`
- `node --check bots/gatewayAgent.js`
- `node --check bots/dispatchAgent.js`
- `node --check bots/newcastAgent.js`
- `npm install` *(fails: EHOSTUNREACH)*